### PR TITLE
💎 chore: Auto-publish releases to Github Packages

### DIFF
--- a/.github/workflows/publish-gem-release.yml
+++ b/.github/workflows/publish-gem-release.yml
@@ -1,0 +1,21 @@
+name: Publish Gem Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - uses: planningcenter/gh-action-publish-internal-gem@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the same workflow[^1] as our other internal gems to release new tags to our Github Packages gem server. 

This'll let us import them like "normal" gems, vs. without the `pco_gem` helper.
```
source "https://rubygems.pkg.github.com/planningcenter" do
  gem 'ri_cal'
end
```

[^1]: https://github.com/planningcenter/.github/blob/main/workflow-templates/publish-gem-release.yml

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209203799634739